### PR TITLE
meetings: add write perms

### DIFF
--- a/.github/workflows/generate-meeting-agendas.yml
+++ b/.github/workflows/generate-meeting-agendas.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   meeting:
     runs-on: ubuntu-latest
@@ -17,7 +21,7 @@ jobs:
         uses: 'pkgjs/meet@v0'
         with:
           issueTitle: 'TSC Meeting <%= date.toFormat("dd-MMMM-yyyy") %>'
-          token: ${{ secrets.WEBPACK_GITHUB_BOT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           orgs: webpack,webpack-contrib
           agendaLabel: 'tsc-agenda'
           meetingLabels: 'meeting'


### PR DESCRIPTION
This would be a test to see if it's no longer necessary for @ovflowd to add their token. I'm not sure what permissions the actions have in this repository, but if my theory is correct, this should solve the initial issue.