### PR TITLE
fix(meetings): align P4W schedule anchor to land on Jun 15

### DIFF
--- a/.github/workflows/generate-meeting-agendas.yml
+++ b/.github/workflows/generate-meeting-agendas.yml
@@ -26,7 +26,7 @@ jobs:
           orgs: webpack,webpack-contrib
           agendaLabel: 'tsc-agenda'
           meetingLabels: 'meeting'
-          schedules: '2025-05-05T11:00:00.0[America/Chicago]/P4W'
+          schedules: '2026-05-18T11:00:00.0[America/Chicago]/P4W'
           createWithin: 'P7D'
           issueTemplate: 'meeting-agenda.md'
 


### PR DESCRIPTION
The 2026-05-16 change to a P4W (4-week) cadence kept the original anchor (2025-05-05), so the series landed on 2026-06-01 / 2026-06-29 and skipped the expected 2026-06-15 meeting. No agenda issue was created for it.

Move the anchor to 2026-05-18 (4 weeks before 2026-06-15) so the 4-week series falls on 2026-06-15, 2026-07-13, ... while keeping the monthly cadence intact.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
<!-- Any other information related to changes. -->

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

<!-- E.g. a fix, feat, refactor, perf, test, chore, ci, build, style, revert, docs or describe it if you did not find a suitable kind of change. -->

**Did you add tests for your changes?**

<!-- Please note: in most cases, if you change the code, we will not merge your changes unless you add tests. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**If relevant, what needs to be documented once your changes are merged or what have you already documented?**

<!-- List all the information that needs to be added to the documentation after merge that has already been documented in this PR. -->

**Use of AI**

<!-- If you have used AI, please state so here. Explain how you used it. 
Make sure to read our AI policy (https://github.com/webpack/governance/blob/main/AI_POLICY.md) or your Pull Request may be closed due inresponsible use of AI. -->