### PR TITLE
feat: audit organization for inactive users

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,4 +15,4 @@ jobs:
           org: webpack
           token: ${{ secrets.WEBPACK_GITHUB_BOT_TOKEN }}
           interaction-types: commit,pr,pr-review,pr-comment,issue,issue-comment
-          ignore-members: sokra,TheLarkInn
+          ignore-members: sokra,TheLarkInn,webpack-bot

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,17 @@
+name: Audit organization
+on:
+  schedule:
+    - cron: '0 9 * * 1' # every Monday 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: avivkeller/organization-auditor@3e155998973c09aa5fa7e88a72c8558b2c3665b0 # v1.1.0
+        with:
+          org: webpack
+          token: ${{ secrets.WEBPACK_GITHUB_BOT_TOKEN }}
+          interaction-types: commit,pr,pr-review,pr-comment,issue,issue-comment

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,3 +15,4 @@ jobs:
           org: webpack
           token: ${{ secrets.WEBPACK_GITHUB_BOT_TOKEN }}
           interaction-types: commit,pr,pr-review,pr-comment,issue,issue-comment
+          ignore-members: sokra,TheLarkInn


### PR DESCRIPTION
cc @webpack/TSC

## Output of this workflow as of June 16th

````
# Organization Inactivity Audit - webpack

_Run: 2026-06-16T17:27:56.341Z · Window: last 90 days · Inactive: 40/56_

## Summary
- Inactive members: 40
- Members with no team: 1
- Members with no recent activity: 40
- Both signals: 1
## Inactive members

| Login | Reason | Last seen | Teams |
|---|---|---|---|
| @3ru | no-activity | - | `contributor-team` |
| @anshumanv | no-activity | - | `cli-team`, `contributor-team` |
| @AugustinMauroy | no-activity | - | `design-wg` |
| @burhanuday | no-activity | - | `cli-team`, `documentation-team` |
| @danez | no-activity, no-team | - | - |
| @eemeli | no-activity | - | `contributor-team` |
| @EslamHiko | no-activity | - | `contributor-team` |
| @EugeneHlushko | no-activity | - | `cli-team`, `contributor-team`, `documentation-team` |
| @gajus | no-activity | - | `contributor-team` |
| @glenjamin | no-activity | - | `contributor-team` |
| @hiroppy | no-activity | - | `core-support`, `dev-server-team` |
| @IngwiePhoenix | no-activity | - | `contributor-team` |
| @jamesgeorge007 | no-activity | - | `cli-team`, `contributor-team` |
| @jantimon | no-activity | - | `contributor-team` |
| @jeffin143 | no-activity | - | `contributor-team` |
| @jeremenichelli | no-activity | - | `contributor-team`, `documentation-team` |
| @Jessidhia | no-activity | - | `contributor-team` |
| @jevancc | no-activity | - | `contributor-team` |
| @jhnns | no-activity | - | `contributor-team`, `core-wg` |
| @joshwiens | no-activity | - | `contributor-team`, `core-wg` |
| @keblodev | no-activity | - | `contributor-team` |
| @knagaitsev | no-activity | - | `contributor-team`, `dev-server-team` |
| @Legends | no-activity | - | `contributor-team` |
| @mc-zone | no-activity | - | `contributor-team` |
| @mohsen1 | no-activity | - | `contributor-team` |
| @montogeek | no-activity | - | `contributor-team`, `core-support`, `documentation-team` |
| @Munter | no-activity | - | `contributor-team` |
| @piecyk | no-activity | - | `contributor-team` |
| @RafaelGSS | no-activity | - | `security-wg` |
| @rishabh3112 | no-activity | - | `cli-team`, `contributor-team` |
| @sapegin | no-activity | - | `contributor-team` |
| @ScriptedAlchemy | no-activity | - | `contributor-team` |
| @sokra | no-activity | - | `contributor-team`, `core-support`, `core-wg`, `documentation-team` |
| @SpaceK33z | no-activity | - | `contributor-team`, `core-wg`, `dev-server-team`, `documentation-team` |
| @th0r | no-activity | - | `contributor-team` |
| @TheDutchCoder | no-activity | - | `contributor-team` |
| @TheLarkInn | no-activity | - | `contributor-team`, `core-support`, `core-wg`, `documentation-team` |
| @vankop | no-activity | - | `contributor-team`, `core-support` |
| @webpack-bot | no-activity | - | `core-wg` |
| @xtuc | no-activity | - | `contributor-team` |



<sub>Generated by organization-auditor. Body is overwritten on each run; comments preserved.</sub>
````